### PR TITLE
link to REP and BM25F

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ ISSN={0098-5589},
 ## Data and Scripts
 
 The replication package containing all data and source code used in our experiments can be downloaded [here](https://github.com/SAILResearch/replication-duplicates_classical_realistic/releases/latest)
+
+The REP and BM25F implementation that we used comes from https://chengniansun.bitbucket.io/projects/bug-report/fast-dbrd.tgz.


### PR DESCRIPTION
added explicit link to the REP and BM25F source code, which we use in the replication package